### PR TITLE
z-index für Buttonleiste eines mblock Items

### DIFF
--- a/assets/mblock.css
+++ b/assets/mblock.css
@@ -36,6 +36,7 @@ div.sortable-ghost {
     position: absolute;
     right: 15px;
     top: 9px;
+    z-index: 1;
 }
 
 .mblock_wrapper span.removeadded .btn {


### PR DESCRIPTION
Der Formularteil / Inhalt eines mblock Items überlagert ohne z-index einen Teil der Buttonleiste, da er im Quelltext nach der absolut positionierten  Buttonleiste kommt:

![zindex](https://user-images.githubusercontent.com/7223820/47247081-9f737580-d401-11e8-865b-178c74a85982.png)
