### PR TITLE
Update MBlockElementReplacer.php

### DIFF
--- a/lib/MBlock/Replacer/MBlockElementReplacer.php
+++ b/lib/MBlock/Replacer/MBlockElementReplacer.php
@@ -95,7 +95,7 @@ class MBlockElementReplacer
                     break;
                 case 'textarea':
                     if ($matches && is_array($item->getVal()) && array_key_exists($matches[1], $item->getVal())) {
-                        $result = $item->getVal();
+                        $result = $item->getResult() ?: $item->getVal();
                         $id = uniqid(md5(rand(1000, 9999)), true);
                         // node value cannot contains &
                         // so set a unique id there we replace later with the right value


### PR DESCRIPTION
`$item->getVal()` nur laden, wenn `$item->getResult()` `null` ist. Andernfalls `$item->getResult()` laden, ansonsten werden bei mehreren textareas in einem `$item` die bereits gesetzten id/value arrays wieder überschrieben und man hat eine [zufällig generierte id](https://github.com/FriendsOfREDAXO/mblock/blob/feature/mblock4/lib/MBlock/Replacer/MBlockElementReplacer.php#L102) als Inhalt in der textarea stehen.