### PR TITLE
fix "Deprecated: mb_convert_encoding()" Warning

### DIFF
--- a/lib/MBlock/Decorator/MBlockReplacerTrait.php
+++ b/lib/MBlock/Decorator/MBlockReplacerTrait.php
@@ -21,7 +21,7 @@ trait MBlockDOMTrait
     private static function createDom($html)
     {
         $dom = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+        $html = htmlspecialchars_decode(iconv('UTF-8', 'ISO-8859-1', htmlentities($html, ENT_COMPAT, 'UTF-8')), ENT_QUOTES);
         @$dom->loadHTML("<html xmlns=\"http://www.w3.org/1999/xhtml\"><body>$html</body></html>");
         $dom->preserveWhiteSpace = false;
         return $dom;


### PR DESCRIPTION
Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in src\addons\mblock\lib\MBlock\Decorator\MBlockReplacerTrait.php on line 24

Ein gewisser @gharlan hat das auch hier https://github.com/symfony/symfony/issues/44281 gemeldet... :-)

Die Lösung dort habe ich dann wiederum angepasst, weil  `utf8_decode()` auch depreacted ist.