### PR TITLE
fix problems with iconv on some servers

### DIFF
--- a/lib/MBlock/Decorator/MBlockReplacerTrait.php
+++ b/lib/MBlock/Decorator/MBlockReplacerTrait.php
@@ -21,7 +21,12 @@ trait MBlockDOMTrait
     private static function createDom($html)
     {
         $dom = new DOMDocument();
-        $html = htmlspecialchars_decode(iconv('UTF-8', 'ISO-8859-1//IGNORE', htmlentities($html, ENT_COMPAT, 'UTF-8')), ENT_QUOTES);
+        //replaces $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+        $html = preg_replace_callback('/[\x{80}-\x{10FFFF}]/u', function ($match) {
+            $utf8 = $match[0];
+            return '&#' . \IntlChar::ord($utf8) . ';';
+        }, htmlentities($html, ENT_COMPAT, 'UTF-8'));
+        $html = htmlspecialchars_decode($html,ENT_QUOTES);
         @$dom->loadHTML("<html xmlns=\"http://www.w3.org/1999/xhtml\"><body>$html</body></html>");
         $dom->preserveWhiteSpace = false;
         return $dom;


### PR DESCRIPTION
a real replacement for deprecated mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8')

Ich musste meinen eigenen PR fixen :-)
Den Ersatz für oben genannte Funktion, den ich letztens gebaut hatte, machte auf einem meiner Hostings Probleme. Ursache war wohl, dass dort eben iconv() nicht wie erwartet funktioniert.
Da iconv() eh als nicht so zuverlässig gilt, habe ich eine neue Funktion gebaut, die auf der intl-PHP-Erweiterung basiert.