### PR TITLE
Change header level for markitup and ckeditor notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _English:_ MBlock lets you create an unlimited number of data blocks within a si
 
 > Please note: The examples are valid for MForm version 8 and higher. MBlock now requires the bloecks addon (^5.2.0) for modern drag & drop functionality.
 
-### 🚨 Hinweis für markitup- und ckeditor-Nutzer 
+## 🚨 Hinweis für markitup- und ckeditor-Nutzer 
 
 Copy & Paste funktioniert leider nicht! 
 


### PR DESCRIPTION
wirft ne Exception beim click auf das Hilfe Icon in der AddOn Verwaltung

![Zwischenablage-1](https://github.com/user-attachments/assets/710ca61e-ffc6-4d79-85e5-4385f1e80e7b)
